### PR TITLE
Fix issue when data is split over multiple chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Fixed issue with large bulk requests that were split into multiple chunks, which caused it to lose it's place in the decoding
+  
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/logstash-codec-es_bulk.gemspec
+++ b/logstash-codec-es_bulk.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-es_bulk'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec decodes messages received in the Elasticsearch bulk format"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixed issue where data that is split over multiple chunks causes the decoder to reset the state, expecting the first line to be the metadata when it might not be, and losing the last piece of metadata from the previous chunk