### PR TITLE
Make sure the devutils rspec helper are loaded before the test

### DIFF
--- a/spec/codecs/es_bulk_spec.rb
+++ b/spec/codecs/es_bulk_spec.rb
@@ -1,3 +1,4 @@
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/es_bulk"
 require "logstash/event"
 require "insist"


### PR DESCRIPTION
We need to make sure the devutils are loaded before running expectation
to make sure log4j is correctly setup.

Fixes: #13
