### PR TITLE
[Doc] Add info on processing order for http-input codec and additional_codecs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,3 +26,14 @@ into individual events, plus metadata into the `@metadata` field.
 Encoding is not supported at this time as the Elasticsearch
 output submits Logstash events in bulk format.
 
+[id="plugins-{type}s-{plugin}-codec-settings"] 
+==== Codec settings in the `logstash-input-http` plugin 
+
+The {logstash-ref}/plugins-inputs-http.html[input-http] plugin has two
+configuration options for codecs: `codec` and `additional_codecs`. 
+
+Values in `additional_codecs` are prioritized over those specified in the
+`codec` option. That is, the default `codec` is applied only if no codec
+for the request's content-type is found in the `additional_codecs` setting.
+
+


### PR DESCRIPTION
Fixes #15 
Explain processing order for  http-input's `codec` and `additional_codecs` options.

