### PR TITLE
bump to 3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Add documentation about use with http input
+
 ## 3.0.6
   - Update gemspec summary
 

--- a/logstash-codec-es_bulk.gemspec
+++ b/logstash-codec-es_bulk.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-es_bulk'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the Elasticsearch bulk format into separate events, along with metadata"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
% git lg v3.0.6..
* 66f4c2d - (origin/master, jsvd/bump_3_0_7, master) Add info on processing order for http-input codec and additional_codecs (4 weeks ago) <Karen Metts>
* 6ee3b80 - [skip ci] Travis: update LOGSTASH_BRANCH from 6.[0..4] to 6.5 (4 weeks ago) <Rob Bavey>
* 57664bd - pin bundler version to < 2 (5 weeks ago) <Rob Bavey>
* 281c6f8 - [skip ci] update license to 2018 (1 year, 1 month ago) <Joao Duarte>
```